### PR TITLE
Undefined name: CITY --> city

### DIFF
--- a/core.py
+++ b/core.py
@@ -132,7 +132,7 @@ def get_house_percommunity(city, communityname):
                 info_dict.update({u'link': housetitle.a.get('href')})
 
                 houseaddr = name.find("div", {"class": "address"})
-                if CITY == 'bj':
+                if city == 'bj':
                     info = houseaddr.div.get_text().split('/')
                 else:
                     info = houseaddr.div.get_text().split('|')


### PR DESCRIPTION
'__CITY__' (all uppercase) is an undefined name in this context so this PR proposes replacing it with '__city__' (all lowercase).

[flake8](http://flake8.pycqa.org) testing of https://github.com/XuefengHuang/lianjia-scrawler on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./core.py:135:20: F821 undefined name 'CITY'
                if CITY == 'bj':
                   ^
1     F821 undefined name 'CITY'
1
```